### PR TITLE
(#44) laxar_application_dependencies: introduce laxar-application package...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Last Changes
 
+- [#44](https://github.com/LaxarJS/grunt-laxar/issues/44): laxar_application_dependencies: use laxar-application package to allow for using relative AMD-paths from widgets, even with plugins
+    + **BREAKING CHANGE:** see ticket for details
 - [#42](https://github.com/LaxarJS/grunt-laxar/issues/42): laxar_application_dependencies: cleaned up some fallout of (#29)
 
 

--- a/tasks/laxar_application_dependencies.js
+++ b/tasks/laxar_application_dependencies.js
@@ -69,6 +69,7 @@ module.exports = function( grunt ) {
 
          var options = this.options( {
             base: '.',
+            applicationPackage: 'laxar-application',
             laxar: 'laxar',
             pages: 'laxar-path-pages',
             widgets: 'laxar-path-widgets',
@@ -93,7 +94,7 @@ module.exports = function( grunt ) {
          grunt.verbose.writeln( 'laxar_application_dependencies: instantiating widget collector' );
          var widgetCollector = WidgetCollector.create(
             client,
-            path.relative( config.baseUrl, paths.WIDGETS ),
+            path.join( options.applicationPackage, path.relative( options.base, paths.WIDGETS ) ),
             pageLoader
          );
 

--- a/tasks/spec/expected/laxar_application_dependencies.js
+++ b/tasks/spec/expected/laxar_application_dependencies.js
@@ -1,7 +1,7 @@
 define( [
-   '../widgets/default/test_widget/test_widget',
-   '../widgets/default/local_widget/local_widget',
-   '../widgets/default/plain_widget/plain_widget'
+   'laxar-application/widgets/default/test_widget/test_widget',
+   'laxar-application/widgets/default/local_widget/local_widget',
+   'laxar-application/widgets/default/plain_widget/plain_widget'
 ], function() {
    'use strict';
 

--- a/tasks/spec/fixtures/require_config.js
+++ b/tasks/spec/fixtures/require_config.js
@@ -15,6 +15,11 @@ require.config( {
          name: 'laxar_uikit',
          location: 'laxar_uikit',
          main: 'laxar_uikit'
+      },
+      {
+         name: 'laxar-application',
+         location: '..',
+         main: 'init'
       }
    ],
    paths: {


### PR DESCRIPTION
...to allow for using relative AMD-paths from widgets, even with plugins